### PR TITLE
Add getUserSpotify function and route

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -11,13 +11,15 @@ const userResponse = (user, withId = true) => {
   const { username, email, _id, spotifyUserId, lat, lng, songInfo } = user;
   var toReturn = {
     username,
-    email,
     spotifyUserId,
     lat,
     lng,
     songInfo,
   };
-  if (withId) toReturn.id = _id;
+  if (withId) {
+    toReturn.id = _id;
+    toReturn.email = email;
+  }
   return toReturn;
 };
 
@@ -42,6 +44,23 @@ export const getUser = async (req, res) => {
     const user = await UserSchema.findById(id);
     const toReturn = userResponse(user);
     res.status(200).json(toReturn);
+  } catch (error) {
+    res.status(404).json({ message: error.message });
+  }
+};
+
+export const getUserSpotify = async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const user = await UserSchema.findOne({ spotifyUserId: id });
+    if (user) {
+      const toReturn = userResponse(user, false);
+      res.status(200).json(toReturn);
+    } else
+      res
+        .status(404)
+        .json({ message: `User with spotify id ${id} doesn't exist` });
   } catch (error) {
     res.status(404).json({ message: error.message });
   }

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -3,6 +3,7 @@ import express from "express";
 import {
   getUsers,
   getUser,
+  getUserSpotify,
   createUser,
   updateUser,
   deleteUser,
@@ -14,6 +15,7 @@ const router = express.Router();
 router.get("/", getUsers);
 router.post("/", createUser);
 router.get("/:id", getUser);
+router.get("/spotify/:id", getUserSpotify);
 router.patch("/:id", updateUser);
 router.delete("/:id", deleteUser);
 router.post("/login", loginUser);

--- a/server/test/integration/user.test.js
+++ b/server/test/integration/user.test.js
@@ -111,7 +111,6 @@ describe("GET /", () => {
     const data = getData(resp.body);
     const expected = {
       username: testUser.username,
-      email: testUser.email,
     };
     expect(data).toEqual(expect.arrayContaining([expected]));
   });
@@ -128,7 +127,7 @@ describe("PATCH /:id", () => {
   let mockUser;
   beforeAll(async () => {
     const resp = await request.post("/users/").send(testUser);
-    mockUser = resp.body.data;
+    mockUser = getData(resp.body);
   });
 
   it("Successfully updates user", async () => {


### PR DESCRIPTION
- We need to request for song information every 5 seconds, so fetching the whole list of users it's heavy
- This functions will allow the functionality to just click on a user and only fetch for that user's song info instead of the entire list. We don't return the db user id in getUsers, so using I'm using `findOne({ spotifyUserId }` 